### PR TITLE
Fixed misspelled bash type in run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ADD run.sh /opt/titan-1.0.0-hadoop1/
 EXPOSE 8182
 EXPOSE 8184
 
-CMD ["/bin/sh", "-e", "/opt/titan-1.0.0-hadoop1/run.sh"]
+CMD ["/bin/bash", "-e", "/opt/titan-1.0.0-hadoop1/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bssh
+#!/bin/bash
 
 BIN=./bin
 SLEEP_INTERVAL_S=2


### PR DESCRIPTION
Also, changed shell to be explicit to prevent shell confusion in different flavors of Linux.  I was getting error messages when executing run.sh and I suspected that /bin/sh was being interpreted to mean 'dash' instead of 'bash' in Centos 7.